### PR TITLE
Changed default argument to NoneType in savedocs and saveadoc endpoints

### DIFF
--- a/modules/servdocs.py
+++ b/modules/servdocs.py
@@ -60,8 +60,8 @@ def savedocs():
     '''
     try:
         timehash = sha256(str(time.time()).encode("UTF-8")).hexdigest()
-        filename = request.args.get("filename", "0", type=str) + "_" + timehash + ".swd"
-        document = request.args.get("document", "0", type=str)
+        filename = request.args.get("filename", None, type=str) + "_" + timehash + ".swd"
+        document = request.args.get("document", None, type=str)
         docsdict = json.loads(document)
         with open(storedir + "/" + filename, "w") as jsonfile:
             json.dump(docsdict, jsonfile)
@@ -77,8 +77,8 @@ def saveadoc():
     '''
     try:
         timehash = sha256(str(time.time()).encode("UTF-8")).hexdigest()
-        filename = request.args.get("filename", "0", type=str) + "_" + timehash + ".adoc"
-        document = request.args.get("document", "0", type=str)
+        filename = request.args.get("filename", None, type=str) + "_" + timehash + ".adoc"
+        document = request.args.get("document", None, type=str)
         docsdict = json.loads(document)
         docsname = docsdict["adocasst"]["docsname"]
         textdata = docsdict["adocasst"]["textdata"]


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

This protects the `/savedocs/` endpoint from being abused to fill the disk storage.

**Description**

This PR fixes #106.

**Have you read the [Contributing Guidelines](https://github.com/t0xic0der/syngrafias/blob/master/CONTRIBUTING.md) before opening this PR**
Yes.

**Notes for Reviewers**
Earlier if you opened up the `/savedocs/` endpoint on browser, it would have stored an empty file in the server storage. This won't happen anymore. Try invoking the endpoint now and you'd get a `savefail` result.